### PR TITLE
feat: add BBS segment after revival clear

### DIFF
--- a/src/router.js
+++ b/src/router.js
@@ -2,11 +2,13 @@ import { createRouter, createWebHashHistory } from 'vue-router'
 import Home from './views/Home.vue'
 import GameRevivalPixi from './views/GameRevivalPixi.vue'
 import GameInitialPixi from './views/GameInitialPixi.vue'
+import BBSView from './views/BBSView.vue'
 
 const routes = [
   { path: '/', name: 'home', component: Home },
   { path: '/revival', name: 'revival', component: GameRevivalPixi },
   { path: '/initial', name: 'initial', component: GameInitialPixi },
+  { path: '/bbs', name: 'bbs', component: BBSView },
 ]
 
 const router = createRouter({

--- a/src/views/GameRevivalPixi.vue
+++ b/src/views/GameRevivalPixi.vue
@@ -11,6 +11,11 @@
 
 <script setup>
 import { ref, onMounted, onBeforeUnmount } from 'vue'
+import { useRouter } from 'vue-router'
+import { useGameStore } from '../store'
+
+const router = useRouter()
+const store = useGameStore()
 
 // ========= 解像度設計 =========
 const LO_W = 450, LO_H = 300
@@ -527,8 +532,15 @@ function resetRun(){
   buildStage()
 }
 async function nextLevel(){
-  if(state.level<3){ state.level++; buildStage() }
-  else { state.cleared = true; state.mode='clear'; state.message=null }
+  if(state.level<3){
+    state.level++
+    buildStage()
+  } else {
+    state.cleared = true
+    state.mode='clear'
+    state.message = null
+    store.revivalCleared = true
+  }
 }
 
 function startGame(){ state.mode='play'; resetRun() }
@@ -555,7 +567,11 @@ function loop(ts){
   if(state.mode==='clear'){
     // 背景に最後のステージをうっすら（任意：ここでは暗転のみ）
     drawGameClearScreen()
-    if(justPressed('e')){ state.mode='title'; state.cleared=false; state.message=null }
+    if(justPressed('e')){
+      store.dmIndex = 0
+      router.push('/')
+      return
+    }
     ctx.imageSmoothingEnabled=false
     ctx.clearRect(0,0,W,H)
     ctx.drawImage(lo, 0,0,LO_W,LO_H, 0,0, W, H)


### PR DESCRIPTION
## Summary
- route game clear to a new DM sequence that guides players to the BBS mini puzzle
- handle DM data based on story progression, linking to the bulletin board
- register `/bbs` route for the mini puzzle screen

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68bb20a23428832da801554cddf7379e