### PR TITLE
feat: refresh DM view with material styling

### DIFF
--- a/src/assets/styles.css
+++ b/src/assets/styles.css
@@ -18,12 +18,21 @@ button{cursor:pointer}
 .btn-primary{border-color:#3156a6;background:#1b2340}
 .btn-primary:hover{background:#22305c}
 .link{color:var(--accent);text-decoration:underline}
-.chat{display:flex;gap:8px;margin:12px 0}
-.chat .bubble{max-width:72%;padding:10px 12px;border-radius:14px;line-height:1.6;border:1px solid #293053}
-.chat.me{justify-content:flex-end}
-.chat .from{font-size:12px;color:#9aa4d4;margin-bottom:4px}
-.bubble.me{background:#20305c}
-.bubble.you{background:#202634}
+.chat{display:flex;gap:12px;margin:14px 0;align-items:flex-end}
+.chat.me{flex-direction:row-reverse}
+.chat .avatar{
+  width:44px;height:44px;border-radius:50%;overflow:hidden;
+  box-shadow:0 14px 28px rgba(44,76,149,0.22);
+  border:2px solid #fff;
+  background:#fff;
+  flex-shrink:0;
+}
+.chat .avatar img{width:100%;height:100%;object-fit:cover;display:block}
+.chat .bubble-wrap{display:flex;flex-direction:column;gap:6px;align-items:flex-start;flex:1;min-width:0}
+.chat.me .bubble-wrap{align-items:flex-end}
+.chat .from{font-size:12px;color:#5a6fae;font-weight:600;letter-spacing:0.2px;margin-left:4px}
+.chat .bubble{max-width:min(100%,520px);min-width:min(220px,100%);padding:12px 16px;border-radius:18px 18px 18px 8px;line-height:1.6;border:1px solid #dae2ff;background:#fff;color:#27345c;box-shadow:0 14px 32px rgba(44,76,149,0.12);word-break:break-word}
+.chat.me .bubble{border-radius:18px 18px 8px 18px;background:linear-gradient(135deg,#5c8dff 0%,#7da7ff 100%);color:#fff;border:none;box-shadow:0 18px 38px rgba(88,132,255,0.28)}
 .toolbar{display:flex;gap:8px;flex-wrap:wrap;margin-top:8px}
 kbd{background:#17203d;border:1px solid #2a315a;border-bottom-width:2px;border-radius:6px;padding:0 6px}
 .small{opacity:.85;font-size:12px}
@@ -79,12 +88,11 @@ footer{opacity:.7;margin-top:24px;font-size:12px}
 .chatbox {
   height: 520px;
   overflow-y: auto;
-  padding-right: 4px;
   display: flex;
   flex-direction: column;
 }
 .chatbox::-webkit-scrollbar{width:8px}
-.chatbox::-webkit-scrollbar-thumb{background:#2a315a;border-radius:8px}
+.chatbox::-webkit-scrollbar-thumb{background:#c3cffc;border-radius:8px}
 
 
 .choice-bar{display:flex;gap:8px;justify-content:center;margin-top:8px}

--- a/src/components/ChatBubble.vue
+++ b/src/components/ChatBubble.vue
@@ -1,14 +1,21 @@
 <template>
-  <div class="chat" :class="{ me: me }">
-    <div class="bubble" :class="me? 'me':'you'">
-      <div class="from" v-if="from && !me">{{ from }}</div>
-      <div class="text" v-html="html"></div>
+  <div class="chat" :class="{ me: isMe }">
+    <div class="avatar">
+      <img :src="avatar" :alt="avatarAlt" />
+    </div>
+    <div class="bubble-wrap">
+      <div class="from" v-if="displayName">{{ displayName }}</div>
+      <div class="bubble" :class="isMe ? 'me' : 'you'">
+        <div class="text" v-html="html"></div>
+      </div>
     </div>
   </div>
 </template>
 
 <script setup>
 import { computed } from 'vue'
+import mizunoAvatar from '../photo/solo/水野ヒロキ.png'
+import heroAvatar from '../photo/犬.png'
 const props = defineProps({
   from: String,
   text: { type: String, required: true },
@@ -19,4 +26,8 @@ const html = computed(()=>{
   let t = props.text.replace(/(https?:\/\/\S+)/g,'<a class="link" href="$1" target="_blank">$1</a>')
   return t.replace(/\*\*(.*?)\*\*/g,'<b>$1</b>')
 })
+const isMe = computed(()=> props.me || props.from === '主人公')
+const displayName = computed(()=> (isMe.value || !props.from) ? '' : props.from)
+const avatar = computed(()=> isMe.value ? heroAvatar : mizunoAvatar)
+const avatarAlt = computed(()=> isMe.value ? '主人公' : (props.from || '水野ヒロキ'))
 </script>

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -1,17 +1,30 @@
 <template>
-  <div class="card">
-    <h2>DM — 水野ヒロキ</h2>
-    <div class="hr"></div>
-    <div ref="chatRef" class="chatbox">
-      <ChatBubble
-        v-for="(m,idx) in visible"
-        :key="idx"
-        :from="m.from"
-        :text="m.text"
-        :me="m.from==='主人公'"
-      />
+  <div class="card dm-card">
+    <header class="dm-header">
+      <div class="dm-header-avatar">
+        <img :src="mizunoAvatar" alt="水野ヒロキ" />
+      </div>
+      <div class="dm-header-text">
+        <div class="dm-title">水野ヒロキ</div>
+        <div class="dm-subtitle">最近のメッセージ</div>
+      </div>
+      <div class="dm-status">
+        <span class="dm-status-dot"></span>
+        <span>オンライン</span>
+      </div>
+    </header>
+    <div class="dm-body">
+      <div ref="chatRef" class="chatbox dm-chatbox">
+        <ChatBubble
+          v-for="(m,idx) in visible"
+          :key="idx"
+          :from="m.from"
+          :text="m.text"
+          :me="m.from==='主人公'"
+        />
+      </div>
     </div>
-    <div class="toolbar">
+    <div class="toolbar dm-toolbar">
       <RetroButton @click="next">{{ ctaLabel }}</RetroButton>
     </div>
   </div>
@@ -25,6 +38,7 @@ import ChatBubble from '../components/ChatBubble.vue'
 import RetroButton from '../components/RetroButton.vue'
 import dmPrologue from '../data/dm_prologue.json'
 import dmAfter from '../data/dm_after_revival.json'
+import mizunoAvatar from '../photo/solo/水野ヒロキ.png'
 
 const router = useRouter()
 const store = useGameStore()
@@ -68,3 +82,80 @@ function next(){
   }
 }
 </script>
+
+<style scoped>
+.dm-card{
+  padding:0;
+  border:none;
+  border-radius:24px;
+  background:linear-gradient(180deg,#fdfdff 0%,#eef3ff 100%);
+  box-shadow:0 20px 40px rgba(36,58,125,0.22);
+  overflow:hidden;
+}
+.dm-header{
+  display:flex;
+  align-items:center;
+  gap:16px;
+  padding:24px;
+  background:linear-gradient(135deg,#4e7eff 0%,#6fc8ff 100%);
+  color:#fff;
+}
+.dm-header-avatar{
+  width:56px;
+  height:56px;
+  border-radius:50%;
+  overflow:hidden;
+  box-shadow:0 12px 28px rgba(15,29,84,0.35);
+  border:3px solid rgba(255,255,255,0.4);
+  flex-shrink:0;
+}
+.dm-header-avatar img{width:100%;height:100%;object-fit:cover;display:block}
+.dm-header-text{flex:1;display:flex;flex-direction:column;gap:4px}
+.dm-title{font-size:20px;font-weight:700;letter-spacing:0.3px}
+.dm-subtitle{font-size:13px;opacity:0.85}
+.dm-status{display:flex;align-items:center;gap:6px;font-size:12px;font-weight:600;letter-spacing:0.4px}
+.dm-status-dot{
+  width:10px;
+  height:10px;
+  border-radius:50%;
+  background:#8ff0a4;
+  box-shadow:0 0 0 4px rgba(143,240,164,0.24);
+}
+.dm-body{padding:24px;background:transparent}
+.dm-chatbox{
+  background:#fff;
+  border-radius:20px;
+  border:1px solid #e0e7ff;
+  box-shadow:0 12px 32px rgba(59,92,166,0.12);
+  padding:20px 18px;
+}
+.dm-toolbar{
+  padding:20px 24px 24px;
+  background:rgba(246,249,255,0.85);
+  justify-content:flex-end;
+}
+.dm-toolbar :deep(.btn){
+  border:none;
+  border-radius:999px;
+  padding:12px 28px;
+  font-weight:600;
+  letter-spacing:0.2px;
+  background:linear-gradient(135deg,#4e7eff 0%,#6f9dff 100%);
+  color:#fff;
+  box-shadow:0 14px 28px rgba(78,126,255,0.24);
+  transition:transform 0.15s ease,box-shadow 0.15s ease;
+}
+.dm-toolbar :deep(.btn:hover){
+  transform:translateY(-1px);
+  box-shadow:0 18px 34px rgba(78,126,255,0.3);
+}
+.dm-toolbar :deep(.btn:active){
+  transform:translateY(0);
+  box-shadow:0 10px 24px rgba(78,126,255,0.22);
+}
+@media (max-width:640px){
+  .dm-header{flex-direction:column;align-items:flex-start;gap:12px}
+  .dm-header-text{align-items:flex-start}
+  .dm-status{align-self:flex-end}
+}
+</style>


### PR DESCRIPTION
## Summary
- restyle the DM screen with a brighter material-inspired layout and header
- add circular avatars for Mizuno and the protagonist, wiring in the story assets
- refresh chat bubble styles to match the lighter visual direction and prevent awkward line breaks in the text

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d19e176c08832d86ffe59368d72bfb